### PR TITLE
Added shebang to tell unix systems to use node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 'use strict';
 
 const Module = require('module');


### PR DESCRIPTION
Received command not found error when running `node-prototype-repl` on ubuntu: https://stackoverflow.com/questions/34353512/node-npm-package-throw-use-strict-command-not-found-after-publish-and-install-g.

Adding the shebang tells "*nix systems that the interpreter of our JavaScript file should be /usr/bin/env node which looks up for the locally-installed node executable".
- https://medium.com/netscape/a-guide-to-create-a-nodejs-command-line-package-c2166ad0452e
 