### PR TITLE
fix package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Goals:
 
 ### Install
 ```sh
-$ npm install -g nodejs/repl
+$ npm install -g @nodejs/repl
 ```
 ```sh
 $ node-prototype-repl


### PR DESCRIPTION
The `name` in `package.json` is `@nodejs/repl`, so once it's published the install command will be `npm install @nodejs/repl`.