### PR TITLE
Simplify installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,26 @@ Goals:
 ## Usage
 
 ### Install
+1. clone `@nodejs/repl` locally
+    ```sh
+    git clone https://github.com/nodejs/repl.git
+    ```
+1. `cd` to the project directory
+    ```sh
+    cd repl
+    ```
+1. install project dependencies (locally)
+    ```sh
+    npm install
+    ```
+1. install `@nodejs/repl` as a global npm package
+    ```sh
+    npm link
+    ```
+
+### Run
 ```sh
-$ npm install -g nodejs/repl
-```
-```sh
-$ node-prototype-repl
+node-prototype-repl
 ```
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.js",
   "license": "MIT",
   "scripts": {
+    "prepare": "node ./generate_annotations.js",
     "lint": "eslint src"
   },
   "bin": {


### PR DESCRIPTION
Add `prepare` [npm script](https://docs.npmjs.com/misc/scripts) that's run when `npm install` is run locally with no commands (it'll also run before the package is packed and published).

I've also updated the installation instructions, since `@nodejs/repl` hasn't been published to the public npm registry yet.