### PR TITLE
don't annotate missing APIs

### DIFF
--- a/generate_annotations.js
+++ b/generate_annotations.js
@@ -129,5 +129,5 @@ ${[...needToRequire].map((n) => `const ${n} = require('${n}');`).join('\n')}
 
 module.exports = new WeakMap([
 ${out.join(',\n')},
-]);
+].filter(([key]) => key !== undefined));
 `);

--- a/src/annotation_map.js
+++ b/src/annotation_map.js
@@ -768,4 +768,4 @@ module.exports = new WeakMap([
   [http2.createSecureServer, [["?onRequestHandler"],["options","?onRequestHandler"]]],
   [http2.connect, [["authority","?listener"],["authority","?options","?listener"]]],
   [global.queueMicrotask, [["callback"]]],
-]);
+].filter(([key]) => key !== undefined));


### PR DESCRIPTION
Filter out missing APIs before constructing the annotation map, since `undefined` isn't a valid `WeakMap` key.

Before this, the repl crashed failed to launch for me because `fs.lchmod` and `fs.lchmodSync` are [“only available on macOS”](https://nodejs.org/api/fs.html#fs_fs_lchmod_path_mode_callback).