### PR TITLE
fix(highlight): change to ts highlight support

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -41,4 +41,4 @@ const sheet = {
 };
 
 module.exports = (s) =>
-  emphasize.highlight('js', s, sheet).value;
+  emphasize.highlight('ts', s, sheet).value;


### PR DESCRIPTION
Adds support for ts syntax highlighting to REPL input
issue requested in https://github.com/TypeStrong/ts-node/issues/1150 repository

## Proposed Changes

  - change to TS files highlight => `emphasize.highlight('ts', s, sheet).value;`
